### PR TITLE
Errors: shake up how error digests are triggered, catch ints supplied as pin labels.

### DIFF
--- a/gpiodevice/errors.py
+++ b/gpiodevice/errors.py
@@ -34,7 +34,7 @@ class GPIOFound(GPIOBaseError):
         GPIOBaseError.__init__(self, message, icon)
 
 
-def collect(fn):
+def collect(fn, fatal=False):
     def wrapper(*args, **kwargs):
         errors = []
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,3 +10,12 @@ def gpiod():
     sys.modules["gpiod"] = gpiopd
     yield gpiod
     del sys.modules["gpiod"]
+
+
+@pytest.fixture(scope="function", autouse=True)
+def cleanup():
+    yield
+    try:
+        del sys.modules["gpiodevice"]
+    except KeyError:
+        pass

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,22 @@
+import pytest
+
+
+def test_find_chip_by_pins_int(gpiod):
+    import gpiodevice
+
+    with pytest.raises(SystemExit):
+        gpiodevice.find_chip_by_pins(1)
+
+
+def test_find_chip_by_pins_quiet(gpiod):
+    import gpiodevice
+
+    assert gpiodevice.find_chip_by_pins(1, fatal=False) is None
+    assert gpiodevice.find_chip_by_pins("GPIO1", fatal=False) is None
+
+
+def test_find_chip_by_pins_str(gpiod):
+    import gpiodevice
+
+    with pytest.raises(SystemExit):
+        gpiodevice.find_chip_by_pins("GPIO1")

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,4 +1,0 @@
-def test_version(gpiod):
-    import gpiodevice
-
-    assert gpiodevice.find_chip_by_label("test") is None


### PR DESCRIPTION
This change is mostly to shake up how errors are presented when calling `gpiodevice.find_chip_by_pins` using outdated, integer pin numbers. IE:

`gpiodevice.find_chip_by_pins(1)` will produce the errors:

```
Woah there, suitable gpiochip not found!
  ⚠️   /dev/gpiochip4: 1 is an int and has been skipped, did you mean "PIN1" or "GPIO1"?
  ⚠️   /dev/gpiochip3: 1 is an int and has been skipped, did you mean "PIN1" or "GPIO1"?
  ⚠️   /dev/gpiochip2: 1 is an int and has been skipped, did you mean "PIN1" or "GPIO1"?
  ⚠️   /dev/gpiochip1: 1 is an int and has been skipped, did you mean "PIN1" or "GPIO1"?
  ⚠️   /dev/gpiochip0: 1 is an int and has been skipped, did you mean "PIN1" or "GPIO1"?
```