### PR TITLE
Handle user supplied LineRequest/offset.

### DIFF
--- a/gpiodevice/__init__.py
+++ b/gpiodevice/__init__.py
@@ -148,6 +148,10 @@ def find_chip_by_platform():
 
 
 def get_pin(pin, label, settings):
+    # Do nothing if given a user specified LineRequest/offset tuple
+    if isinstance(pin, tuple):
+        return pin
+
     chip = find_chip_by_pins(pin)
     line_offset = chip.line_offset_from_id(pin)
     consumer = Path(sys.argv[0]).stem


### PR DESCRIPTION
Client libraries will use get_pin() to resolve a user-supplied or default pin label to a gpiochip and line offset.

This is intended to fix the issues with Buster not including pin labels - https://github.com/pimoroni/enviroplus-python/issues/137 - though we do not want to make a habit of supporting anything older than Bullseye.

This should also fix other cases where a user supplies a `(LineRequest, offset)` tuple instead of a `"GPIO27"` label. Since the user has already done the legwork of requesting the pin and supplying it to the library, we can return it verbatim. This avoids having to handle this behaviour in every client library.