### PR TITLE
Add support for int pins to get_pin.

### DIFF
--- a/gpiodevice/__init__.py
+++ b/gpiodevice/__init__.py
@@ -152,8 +152,13 @@ def get_pin(pin, label, settings):
     if isinstance(pin, tuple):
         return pin
 
-    chip = find_chip_by_pins(pin)
-    line_offset = chip.line_offset_from_id(pin)
+    if isinstance(pin, int):
+        chip = find_chip_by_platform()
+        line_offset = pin
+    else:
+        chip = find_chip_by_pins(pin)
+        line_offset = chip.line_offset_from_id(pin)
+
     consumer = Path(sys.argv[0]).stem
     lines = chip.request_lines(consumer=f"{consumer}-{label}", config={line_offset: settings})
     return lines, line_offset


### PR DESCRIPTION
If the supplied pin is an int - ie: a line offset value - then try to use find_chip_by_platform() to find the canonical gpiochip.

Previously I had avoided supporting integer pin numbers, since there's no way to identify a gpiochip by a line offset. I don't think labels are much better a proposition, however, so I'm very strongly inclined to phase out all use of "GPIOxx" in downstream libraries and just let gpiodevice find us the right gpiochip. On Pi this is now, in theory, easy since it's glob'd as `pinctrl-*`.

Yes, hindsight is very much 20/20 and without a stern hand on my shoulder and some gentle words of guidance I kinda painted my way into the silliest possible solution while the line offset -> GPIO pin relation was staring me in the face.

I don't believe there are any guarantees that line offset will always equal GPIO number, but we can cross that bridge when we come to it...